### PR TITLE
fix: create session records for documents indexed by 

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -76,6 +76,14 @@ Examples:
 		fileCount := 0
 		totalBytes := int64(0)
 
+		// Start transaction for atomic inserts
+		tx, err := db.BeginTx()
+		if err != nil {
+			fmt.Printf("Error starting transaction: %v\n", err)
+			return
+		}
+		defer func() { _ = tx.Rollback() }()
+
 		if err := filepath.Walk(sourcePath, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return nil
@@ -111,8 +119,20 @@ Examples:
 			relPath, _ := filepath.Rel(sourcePath, path)
 			sessionID := fmt.Sprintf("doc:%s:%s", addName, relPath)
 
+			// Create session record first (required for search to work)
+			firstQuery := relPath // Use filename as first query
+			if len(firstQuery) > 200 {
+				firstQuery = firstQuery[:200] // Truncate if too long
+			}
+
+			err = db.TxInsertSessionSimple(tx, sessionID, addName, firstQuery, path, "docs", 1)
+			if err != nil {
+				fmt.Printf("Warning: failed to create session for %s: %v\n", relPath, err)
+				return nil
+			}
+
 			// Insert as a document
-			err = db.InsertMessage(db.Message{
+			err = db.TxInsertMessage(tx, db.Message{
 				SessionID: sessionID,
 				Project:   addName,
 				Role:      "document",
@@ -130,6 +150,12 @@ Examples:
 			return nil
 		}); err != nil {
 			fmt.Printf("Error walking directory: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Commit transaction
+		if err := tx.Commit(); err != nil {
+			fmt.Printf("Error committing transaction: %v\n", err)
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
## Summary
Fixes #1 - `mnemo add` now creates proper session records for each indexed document, ensuring they appear in search results.

## Problem
Previously, `mnemo add` inserted documents into the `messages` table without creating corresponding `sessions` records. The `SearchGrouped()` function silently skipped results without sessions, making indexed documents invisible to default search.

## Changes
- Wrap file indexing in transaction for atomicity
- Create session record before inserting document message
- Use `TxInsertSessionSimple` for minimal session metadata
- Each document gets its own session (similar to tool indexers)

## Testing
Created test markdown files and verified:
```bash
./mnemo add /tmp/test-mnemo-docs --name "test-docs" --non-interactive
# ✓ Indexed 2 files

./mnemo search "Feature one" --non-interactive
# test-docs  1 matches  0m ago  docs
# test1.md
```

Verified session records in DB:
```sql
SELECT id, project FROM sessions WHERE project = 'test-docs';
doc:test-docs:test1.md|test-docs
doc:test-docs:test2.md|test-docs
```

## Test plan
- [x] Test `mnemo add` creates session records
- [x] Test `mnemo search` finds indexed documents
- [x] Test in headless mode
- [x] Build succeeds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)