### PR TITLE
chore: add homebrew-tap auto-bump workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,30 @@
+# mnemo — notes for Claude Code sessions
+
+## Release checklist (CRITICAL — do not skip)
+
+When the user asks to "cut a release", "tag a version", or merges a version bump:
+
+1. Ensure `CHANGELOG.md` has an entry for the new version.
+2. Tag: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+3. **Verify the `Bump Homebrew Formula` workflow ran.** It lives in
+   `.github/workflows/release.yml` and requires the `HOMEBREW_TAP_PAT` repo
+   secret. It opens a PR on `Pilan-AI/homebrew-tap`.
+4. Review and merge the tap PR. Until it's merged, `brew upgrade mnemo` stays
+   on the old version.
+5. Optionally: `gh release create vX.Y.Z --generate-notes`.
+
+If the workflow didn't fire or failed, fall back to the manual instructions in
+[`RELEASING.md`](../RELEASING.md).
+
+**History of this bug:** `Pilan-AI/mnemo#8` — the tap drifted from v1.0.0 to
+v1.3.4 (7 releases) because releases were tagged without bumping the formula.
+Shipping a tag is not shipping a release; the formula bump is the last mile.
+
+## Other context
+
+- Module path: `github.com/0xRaghu/mnemo` (note the `0xRaghu`, not `Pilan-AI`).
+  The `go build -ldflags -X ...cmd.Version=` injection in the formula depends
+  on this exact path.
+- Homebrew tap: `Pilan-AI/homebrew-tap`, formula at `Formula/mnemo.rb`.
+- License is AGPL-3.0-or-later (see `LICENSE`), not MIT — `CONTRIBUTING.md` has
+  a stale MIT mention that should get fixed opportunistically.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Bump Homebrew Formula
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v1.3.4)'
+        required: true
+
+jobs:
+  homebrew:
+    name: Update homebrew-tap
+    runs-on: ubuntu-latest
+    env:
+      # Funnel all untrusted refs through env so they never interpolate into shell/action args directly.
+      RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+    steps:
+      - name: Validate tag name
+        run: |
+          if ! printf '%s' "$RELEASE_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$'; then
+            echo "Refusing to bump — tag '$RELEASE_TAG' is not a valid semver-style tag." >&2
+            exit 1
+          fi
+
+      - name: Bump formula in Pilan-AI/homebrew-tap
+        uses: mislav/bump-homebrew-formula-action@v3
+        with:
+          formula-name: mnemo
+          formula-path: Formula/mnemo.rb
+          homebrew-tap: Pilan-AI/homebrew-tap
+          base-branch: main
+          tag-name: ${{ env.RELEASE_TAG }}
+          download-url: https://github.com/Pilan-AI/mnemo/archive/refs/tags/${{ env.RELEASE_TAG }}.tar.gz
+          commit-message: |
+            {{formulaName}} {{version}}
+
+            Auto-bump from Pilan-AI/mnemo release {{version}}
+        env:
+          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_PAT }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,49 @@
+# Releasing mnemo
+
+## Cutting a release
+
+1. Update `CHANGELOG.md` with the new version's notes.
+2. Tag and push:
+
+   ```bash
+   git tag v1.x.y
+   git push origin v1.x.y
+   ```
+
+3. The [`Bump Homebrew Formula`](.github/workflows/release.yml) workflow fires on
+   the tag push and opens a PR against `Pilan-AI/homebrew-tap` bumping
+   `Formula/mnemo.rb` to the new version + sha256. Merge that PR.
+4. Optionally create a GitHub Release from the tag (`gh release create v1.x.y --generate-notes`).
+
+That's it — `brew upgrade mnemo` picks up the new version as soon as the tap PR is merged.
+
+## Required secrets
+
+The release workflow needs one repo secret on `Pilan-AI/mnemo`:
+
+- **`HOMEBREW_TAP_PAT`** — a fine-grained personal access token with
+  `Contents: Read and write` on `Pilan-AI/homebrew-tap`. Set at
+  **Settings → Secrets and variables → Actions → New repository secret**.
+
+If the token expires, the workflow will fail with a 401 from the GitHub API —
+rotate and re-save the secret.
+
+## Manual fallback
+
+If the workflow is broken, bump the tap by hand:
+
+```bash
+TAG=v1.x.y
+SHA=$(curl -sL https://github.com/Pilan-AI/mnemo/archive/refs/tags/$TAG.tar.gz | shasum -a 256 | awk '{print $1}')
+echo "url:    https://github.com/Pilan-AI/mnemo/archive/refs/tags/$TAG.tar.gz"
+echo "sha256: $SHA"
+```
+
+Then update `Pilan-AI/homebrew-tap/Formula/mnemo.rb` with those two values and
+open a PR.
+
+## Why this matters
+
+See `Pilan-AI/mnemo#8` — without the auto-bump workflow the tap drifted 7
+releases behind upstream (v1.0.0 → v1.3.4) before anyone noticed. Don't let that
+happen again.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` — on tag push (`v*`), fires `mislav/bump-homebrew-formula-action` to open a PR on `Pilan-AI/homebrew-tap` bumping `Formula/mnemo.rb` automatically
- Adds `RELEASING.md` documenting the release flow for humans
- Adds `.claude/CLAUDE.md` so Claude Code sessions working on this repo don't skip the formula-bump step
- Untrusted refs (`github.ref_name`, `workflow_dispatch.inputs.tag`) are funneled through an `env:` var with a semver validation step to prevent workflow injection

## Required after merge

Add repo secret `HOMEBREW_TAP_PAT` — a fine-grained PAT with `Contents: Read and write` on `Pilan-AI/homebrew-tap`. Set at **Settings → Secrets and variables → Actions**.

Without this secret, the workflow will fail with a 401 from the GitHub API.

## Context

Pilan-AI/mnemo#8 — tap formula was stuck at v1.0.0 for 7 releases (through v1.3.4) because tagging wasn't bumping the tap. Manual fix in Pilan-AI/homebrew-tap PR ships v1.3.4 immediately; this PR prevents the drift from recurring.

## Test plan

- [ ] Set `HOMEBREW_TAP_PAT` secret
- [ ] Manually trigger via `gh workflow run release.yml -f tag=v1.3.4` and confirm a PR opens on the tap (should noop since tap is already at v1.3.4 post-manual-fix — expected, just verifies the pipeline)
- [ ] On next real release (v1.3.5+), tag-push triggers the workflow automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)