### PR TITLE
fix: resolve OpenCode SQLite indexing deadlock and content extraction

### DIFF
--- a/cmd/index_opencode.go
+++ b/cmd/index_opencode.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/Pilan-AI/mnemo/internal/db"
 )
 
@@ -344,15 +343,11 @@ func getMessageContent(partBasePath, messageID string) string {
 // indexOpenCodeSQLite indexes sessions from OpenCode 1.2.0+ SQLite database.
 // Returns total (sessions, messages) indexed.
 func indexOpenCodeSQLite(dbPath string) (int, int) {
-	sqliteDB, err := sql.Open("sqlite3", dbPath+"?mode=ro")
+	sqliteDB, err := db.OpenReadOnlySQLite(dbPath)
 	if err != nil {
 		return 0, 0
 	}
 	defer func() { _ = sqliteDB.Close() }()
-
-	// Set busy timeout for concurrent access
-	sqliteDB.SetMaxOpenConns(1)
-	sqliteDB.SetMaxIdleConns(1)
 
 	// Get all sessions
 	rows, err := sqliteDB.Query(`

--- a/cmd/index_opencode.go
+++ b/cmd/index_opencode.go
@@ -341,6 +341,9 @@ func getMessageContent(partBasePath, messageID string) string {
 }
 
 // indexOpenCodeSQLite indexes sessions from OpenCode 1.2.0+ SQLite database.
+// Uses a collect-then-process pattern: reads all session metadata into memory,
+// closes the outer cursor, then indexes each session individually. This avoids
+// holding a rows cursor open while making nested queries on the same connection.
 // Returns total (sessions, messages) indexed.
 func indexOpenCodeSQLite(dbPath string) (int, int) {
 	sqliteDB, err := db.OpenReadOnlySQLite(dbPath)
@@ -349,36 +352,43 @@ func indexOpenCodeSQLite(dbPath string) (int, int) {
 	}
 	defer func() { _ = sqliteDB.Close() }()
 
-	// Get all sessions
+	type openCodeSession struct {
+		id        string
+		directory string
+		title     string
+		version   string
+		updated   int64
+	}
+
 	rows, err := sqliteDB.Query(`
-		SELECT id, project_id, directory, title, version, time_created, time_updated
+		SELECT id, directory, title, version, time_updated
 		FROM session
 		ORDER BY time_created DESC
 	`)
 	if err != nil {
 		return 0, 0
 	}
-	defer func() { _ = rows.Close() }()
+
+	var sessions []openCodeSession
+	for rows.Next() {
+		var s openCodeSession
+		if err := rows.Scan(&s.id, &s.directory, &s.title, &s.version, &s.updated); err != nil {
+			continue
+		}
+		if isSessionUnchanged(s.id, time.UnixMilli(s.updated)) {
+			continue
+		}
+		sessions = append(sessions, s)
+	}
+	rows.Close()
 
 	totalSessions := 0
 	totalMessages := 0
 
-	for rows.Next() {
-		var sessionID, projectID, directory, title, version string
-		var timeCreated, timeUpdated int64
-		if err := rows.Scan(&sessionID, &projectID, &directory, &title, &version, &timeCreated, &timeUpdated); err != nil {
-			continue
-		}
-
-		// Skip if session hasn't changed
-		modTime := time.UnixMilli(timeUpdated)
-		if isSessionUnchanged(sessionID, modTime) {
-			continue
-		}
-
-		s, m := indexOpenCodeSQLiteSession(sqliteDB, sessionID, directory, title, version)
-		totalSessions += s
-		totalMessages += m
+	for _, s := range sessions {
+		numS, numM := indexOpenCodeSQLiteSession(sqliteDB, s.id, s.directory, s.title, s.version)
+		totalSessions += numS
+		totalMessages += numM
 	}
 
 	return totalSessions, totalMessages

--- a/cmd/index_opencode.go
+++ b/cmd/index_opencode.go
@@ -450,19 +450,26 @@ func indexOpenCodeSQLiteSession(sqliteDB *sql.DB, sessionID, directory, title, v
 			continue
 		}
 
-		// Extract content from message
-		content := extractMessageContent(msgData)
+		content := getOpenCodeMessageContent(sqliteDB, msgID)
 		if content == "" {
 			continue
 		}
 
 		// Extract model info
 		var model, provider string
-		if modelID, ok := msgData["modelID"].(string); ok {
-			model = modelID
+		if modelMap, ok := msgData["model"].(map[string]interface{}); ok {
+			model, _ = modelMap["modelID"].(string)
+			provider, _ = modelMap["providerID"].(string)
 		}
-		if providerID, ok := msgData["providerID"].(string); ok {
-			provider = providerID
+		if model == "" {
+			if modelID, ok := msgData["modelID"].(string); ok {
+				model = modelID
+			}
+		}
+		if provider == "" {
+			if providerID, ok := msgData["providerID"].(string); ok {
+				provider = providerID
+			}
 		}
 
 		if sessionModel == "" && model != "" {
@@ -597,31 +604,38 @@ func indexOpenCodeSQLiteSession(sqliteDB *sql.DB, sessionID, directory, title, v
 	return 0, 0
 }
 
-// extractMessageContent extracts text content from message data
-func extractMessageContent(msgData map[string]interface{}) string {
-	var contentParts []string
-
-	// Check for direct content field
-	if content, ok := msgData["content"].(string); ok && content != "" {
-		return content
+// getOpenCodeMessageContent queries the part table for a message's text content.
+// OpenCode 1.2.0+ stores message content in a separate part table rather than
+// inline in the message data.
+func getOpenCodeMessageContent(sqliteDB *sql.DB, messageID string) string {
+	partRows, err := sqliteDB.Query(`
+		SELECT data
+		FROM part
+		WHERE message_id = ?
+		ORDER BY time_created ASC
+	`, messageID)
+	if err != nil {
+		return ""
 	}
+	defer func() { _ = partRows.Close() }()
 
-	// Check for parts array (newer format)
-	if parts, ok := msgData["parts"].([]interface{}); ok {
-		for _, part := range parts {
-			if partMap, ok := part.(map[string]interface{}); ok {
-				if partType, ok := partMap["type"].(string); ok && partType == "text" {
-					if text, ok := partMap["text"].(string); ok {
-						contentParts = append(contentParts, text)
-					}
-				}
+	var contentParts []string
+	for partRows.Next() {
+		var partDataJSON string
+		if err := partRows.Scan(&partDataJSON); err != nil {
+			continue
+		}
+		var partData map[string]interface{}
+		if err := json.Unmarshal([]byte(partDataJSON), &partData); err != nil {
+			continue
+		}
+		partType, _ := partData["type"].(string)
+		if partType == "text" {
+			if text, ok := partData["text"].(string); ok && text != "" {
+				contentParts = append(contentParts, text)
 			}
 		}
 	}
 
-	if len(contentParts) > 0 {
-		return strings.Join(contentParts, "\n")
-	}
-
-	return ""
+	return strings.Join(contentParts, "\n")
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/charmbracelet/bubbletea v0.25.0
 	github.com/charmbracelet/lipgloss v0.9.1
 	github.com/mark3labs/mcp-go v0.47.1
-	github.com/mattn/go-sqlite3 v1.14.34
 	github.com/spf13/cobra v1.8.0
 	modernc.org/sqlite v1.28.0
 )
@@ -23,6 +22,7 @@ require (
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/mattn/go-sqlite3 v1.14.34 // indirect
 	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect


### PR DESCRIPTION
## Summary

- Fix deadlock in OpenCode SQLite indexing where the outer `rows` cursor held the only available database connection, blocking the inner per-session message query from acquiring one
- Fix content extraction: OpenCode 1.2.0+ stores message text in a separate `part` table, not inline in `message.data` — the old code always found 0 messages
- Switch OpenCode adapter from `mattn/go-sqlite3` (CGO) to `db.OpenReadOnlySQLite` using `modernc.org/sqlite`, consistent with all other SQLite adapters (Cursor, Crush, VS Code)

## Root Cause

Two bugs in the OpenCode SQLite indexer introduced in PR #4 (v1.3.3):

**Bug 1 — Deadlock:** `indexOpenCodeSQLite()` set `MaxOpenConns(1)` on the OpenCode database, then ran an outer `rows.Next()` loop that held the single connection while calling `indexOpenCodeSQLiteSession()` which tried to open its own query on the same pool — deadlock.

```
goroutine 1 [select]:
database/sql.(*DB).conn
github.com/Pilan-AI/mnemo/cmd.indexOpenCodeSQLiteSession
  github.com/Pilan-AI/mnemo/cmd/index_opencode.go:395
github.com/Pilan-AI/mnemo/cmd.indexOpenCodeSQLite
  github.com/Pilan-AI/mnemo/cmd/index_opencode.go:384
```

**Bug 2 — Empty content:** The OpenCode SQLite schema stores message content in a separate `part` table (joined by `message_id`), not inline in the `message.data` JSON. The old code tried to extract content from `msgData["content"]` and `msgData["parts"]`, neither of which exists in the current schema — causing all messages to be filtered as empty and every session to index 0 messages.

## Changes

**Commit 1 — refactor:** Remove direct `mattn/go-sqlite3` import, use `db.OpenReadOnlySQLite()` (pure-Go `modernc.org/sqlite` driver). This alone prevents the deadlock since `OpenReadOnlySQLite` doesn't set `MaxOpenConns(1)`, but the nested-cursor pattern remained fragile.

**Commit 2 — deadlock fix:** Rewrite `indexOpenCodeSQLite()` to collect all session metadata into a slice, close the outer `rows` cursor, then iterate the slice and query per-session messages. No nested open cursors = no deadlock regardless of connection pool settings. Same pattern used by `indexCrush`.

**Commit 3 — content fix:** Replace `extractMessageContent()` (which read from the `message.data` JSON) with `getOpenCodeMessageContent()` which queries the `part` table for each message's text parts. Also fix model extraction to check the nested `model` object (`{providerID, modelID}`) before falling back to top-level fields.

## Testing

- `go build` and `go test ./...` pass
- Built binary tested against live `~/.local/share/opencode/opencode.db` (~40MB, 60 sessions):
  - Before fix: hangs indefinitely on OpenCode indexing, 0 messages extracted
  - After fix: indexes 55 sessions, 771 messages without hanging; search returns correct results

Fixes #13
