### PR TITLE
chore: publish binary release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Bump Homebrew Formula
+name: Release
 
 on:
   push:
@@ -11,9 +11,11 @@ on:
         required: true
 
 jobs:
-  homebrew:
-    name: Update homebrew-tap
+  goreleaser:
+    name: Build release artifacts
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       # Funnel all untrusted refs through env so they never interpolate into shell/action args directly.
       RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
@@ -25,18 +27,22 @@ jobs:
             exit 1
           fi
 
-      - name: Bump formula in Pilan-AI/homebrew-tap
-        uses: mislav/bump-homebrew-formula-action@v3
+      - name: Checkout release tag
+        uses: actions/checkout@v4
         with:
-          formula-name: mnemo
-          formula-path: Formula/mnemo.rb
-          homebrew-tap: Pilan-AI/homebrew-tap
-          base-branch: main
-          tag-name: ${{ env.RELEASE_TAG }}
-          download-url: https://github.com/Pilan-AI/mnemo/archive/refs/tags/${{ env.RELEASE_TAG }}.tar.gz
-          commit-message: |
-            {{formulaName}} {{version}}
+          fetch-depth: 0
+          ref: ${{ env.RELEASE_TAG }}
 
-            Auto-bump from Pilan-AI/mnemo release {{version}}
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: 'v2.9.0'
+          args: release --clean
         env:
-          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_PAT }}
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_PAT || secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,11 +23,11 @@ builds:
       - -X github.com/Pilan-AI/mnemo/cmd.GitCommit={{.ShortCommit}}
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 checksum:
   name_template: 'checksums.txt'

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you use Claude Code or OpenCode, the plugins give you a much deeper integrati
 mnemo install claude-code
 ```
 
-This installs the [mnemo-memory plugin](https://github.com/Pilan-AI/pilan-plugins) which gives you:
+This installs the [mnemo-memory plugin](#claude-code-plugin) which gives you:
 
 - **Auto-context** — past session context loads automatically when you start working
 - `/mnemo-memory:remember <query>` — search past sessions from inside Claude Code


### PR DESCRIPTION
## Summary

- replace the tag-only Homebrew bump workflow with a GoReleaser release workflow that uploads cross-platform binary archives and checksums
- keep the Homebrew tap update path through the existing GoReleaser config
- update the GoReleaser archive syntax to the current v2 format
- replace the broken external plugin repo README link with the local Claude Code plugin section anchor

## Verification

- go test ./...
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- go run github.com/goreleaser/goreleaser/v2@v2.9.0 check
- go run github.com/goreleaser/goreleaser/v2@v2.9.0 release --snapshot --clean

Closes #11
Closes #12