### PR TITLE
ci: verify release distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,70 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_PAT || secrets.GITHUB_TOKEN }}
+
+  verify:
+    name: Verify release distribution
+    runs-on: ubuntu-latest
+    needs: goreleaser
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Verify GitHub release assets
+        run: |
+          set -euo pipefail
+
+          version="${RELEASE_TAG#v}"
+          release_json="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets,isDraft,isPrerelease,tagName)"
+
+          tag_name="$(jq -r '.tagName' <<<"$release_json")"
+          if [ "$tag_name" != "$RELEASE_TAG" ]; then
+            echo "Release tag mismatch: expected $RELEASE_TAG, got $tag_name" >&2
+            exit 1
+          fi
+
+          if [ "$(jq -r '.isDraft' <<<"$release_json")" != "false" ]; then
+            echo "Release $RELEASE_TAG is still a draft" >&2
+            exit 1
+          fi
+
+          expected_assets=(
+            "checksums.txt"
+            "mnemo_${version}_darwin_amd64.tar.gz"
+            "mnemo_${version}_darwin_arm64.tar.gz"
+            "mnemo_${version}_linux_amd64.tar.gz"
+            "mnemo_${version}_linux_arm64.tar.gz"
+            "mnemo_${version}_windows_amd64.zip"
+            "mnemo_${version}_windows_arm64.zip"
+          )
+
+          asset_names="$(jq -r '.assets[].name' <<<"$release_json" | sort)"
+          echo "$asset_names"
+
+          for asset in "${expected_assets[@]}"; do
+            if ! grep -Fxq "$asset" <<<"$asset_names"; then
+              echo "Missing release asset: $asset" >&2
+              exit 1
+            fi
+          done
+
+      - name: Verify Homebrew tap formula
+        run: |
+          set -euo pipefail
+
+          formula_url="https://raw.githubusercontent.com/Pilan-AI/homebrew-tap/main/Formula/mnemo.rb"
+          formula="$(curl -fsSL "$formula_url")"
+
+          if ! grep -Fq "https://github.com/Pilan-AI/mnemo/archive/refs/tags/${RELEASE_TAG}.tar.gz" <<<"$formula"; then
+            echo "Homebrew formula does not point at ${RELEASE_TAG}" >&2
+            echo "$formula" >&2
+            exit 1
+          fi
+
+          if ! grep -Fq 'system "#{bin}/mnemo", "version"' <<<"$formula"; then
+            echo "Homebrew formula is missing the mnemo version smoke test" >&2
+            echo "$formula" >&2
+            exit 1
+          fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,12 +10,14 @@
    git push origin v1.x.y
    ```
 
-3. The [`Bump Homebrew Formula`](.github/workflows/release.yml) workflow fires on
-   the tag push and opens a PR against `Pilan-AI/homebrew-tap` bumping
-   `Formula/mnemo.rb` to the new version + sha256. Merge that PR.
-4. Optionally create a GitHub Release from the tag (`gh release create v1.x.y --generate-notes`).
+3. The [`Release`](.github/workflows/release.yml) workflow fires on the tag push.
+   It uses GoReleaser to create the GitHub Release, upload cross-platform binary
+   archives + checksums, and bump `Pilan-AI/homebrew-tap`.
+4. The workflow verifies that the GitHub Release has all expected assets and
+   that the Homebrew formula points at the same tag.
 
-That's it — `brew upgrade mnemo` picks up the new version as soon as the tap PR is merged.
+That's it — `brew upgrade mnemo` picks up the new version as soon as the release
+workflow completes.
 
 ## Required secrets
 


### PR DESCRIPTION
## Summary

- add a post-GoReleaser verification job to the release workflow
- assert the GitHub Release has checksums and all six platform archives
- assert the Homebrew tap formula points at the same release tag and keeps a version smoke test
- update RELEASING.md for the current release flow

## Verification

- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- go test ./...