### PR TITLE
ci: use separate token for homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,8 @@ jobs:
           version: 'v2.9.0'
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}
 
   verify:
     name: Verify release distribution

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,6 +44,7 @@ brews:
   - repository:
       owner: Pilan-AI
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_PAT }}"
     homepage: "https://github.com/Pilan-AI/mnemo"
     description: "Memory for AI-assisted development. Search your AI coding sessions."
     license: "MIT"


### PR DESCRIPTION
## Summary

- use the repo-scoped GitHub token for creating the mnemo GitHub Release
- pass HOMEBREW_TAP_PAT separately to GoReleaser's Homebrew tap repository config

## Why

The v1.3.5 release run built binaries successfully but failed to create the GitHub Release because the Homebrew tap PAT did not have release permissions on Pilan-AI/mnemo.

## Verification

- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); YAML.load_file(".goreleaser.yml")'
- go run github.com/goreleaser/goreleaser/v2@v2.9.0 check
- go test ./...