### PR TITLE
ci: publish formula under Formula directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,16 +100,23 @@ jobs:
         run: |
           set -euo pipefail
 
-          formula_url="https://raw.githubusercontent.com/Pilan-AI/homebrew-tap/main/Formula/mnemo.rb"
-          formula="$(curl -fsSL "$formula_url")"
+          version="${RELEASE_TAG#v}"
+          formula="$(gh api 'repos/Pilan-AI/homebrew-tap/contents/Formula/mnemo.rb?ref=main' --jq '.content' | base64 --decode)"
 
-          if ! grep -Fq "https://github.com/Pilan-AI/mnemo/archive/refs/tags/${RELEASE_TAG}.tar.gz" <<<"$formula"; then
-            echo "Homebrew formula does not point at ${RELEASE_TAG}" >&2
+          if ! grep -Fq "version \"${version}\"" <<<"$formula"; then
+            echo "Homebrew formula version does not match ${RELEASE_TAG}" >&2
             echo "$formula" >&2
             exit 1
           fi
 
-          if ! grep -Fq 'system "#{bin}/mnemo", "version"' <<<"$formula"; then
+          if ! grep -Fq "https://github.com/Pilan-AI/mnemo/releases/download/${RELEASE_TAG}/" <<<"$formula"; then
+            echo "Homebrew formula does not use ${RELEASE_TAG} release assets" >&2
+            echo "$formula" >&2
+            exit 1
+          fi
+
+          if ! grep -Fq 'system "#{bin}/mnemo", "version"' <<<"$formula" &&
+             ! grep -Fq 'assert_match "mnemo", shell_output("#{bin}/mnemo version")' <<<"$formula"; then
             echo "Homebrew formula is missing the mnemo version smoke test" >&2
             echo "$formula" >&2
             exit 1

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,6 +45,7 @@ brews:
       owner: Pilan-AI
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_PAT }}"
+    directory: Formula
     homepage: "https://github.com/Pilan-AI/mnemo"
     description: "Memory for AI-assisted development. Search your AI coding sessions."
     license: "MIT"


### PR DESCRIPTION
## Summary

- set GoReleaser Homebrew formula directory to Formula
- update the release verifier to read Formula/mnemo.rb through the GitHub API
- verify the generated binary formula version and release-asset URLs instead of the old source-tarball URL

## Why

The v1.3.6 release created GitHub release assets successfully, but GoReleaser wrote mnemo.rb at the tap root. The existing Formula/mnemo.rb therefore stayed on v1.3.4 and the verifier correctly failed.

## Verification

- workflow YAML parse
- go run github.com/goreleaser/goreleaser/v2@v2.9.0 check
- go test ./...