### PR TITLE
Fix OpenCode MCP installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ This installs the [mnemo-memory plugin](#claude-code-plugin) which gives you:
 ### OpenCode plugin
 
 ```bash
-mnemo install opencode
+mnemo install
 ```
 
-Adds mnemo as an MCP tool inside OpenCode. Search and context commands available directly in your coding session.
+Adds mnemo as an MCP server inside OpenCode. Search and context tools are available directly in your coding session after restarting OpenCode.
 
 ## MCP server
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -5,7 +5,7 @@ package cmd
 //   - Claude Code: Installs a skill at ~/.claude/skills/mnemo/ that auto-activates
 //     on context-related keywords
 //   - Claude Desktop: Adds mnemo as an MCP server in claude_desktop_config.json
-//   - OpenCode: Installs a plugin that injects mnemo context during session compaction
+//   - OpenCode: Adds mnemo as an MCP server and installs a compaction plugin
 
 import (
 	"encoding/json"
@@ -25,11 +25,12 @@ var installCmd = &cobra.Command{
 
 This command will:
   1. Install Claude Code skill for context keywords
-  2. Install OpenCode plugin for session compaction
+  2. Configure MCP server in OpenCode
   3. Configure MCP server in Claude Desktop (if installed)
+  4. Install OpenCode plugin for session compaction
 
 The MCP server provides tools like mnemo_search, mnemo_context, and mnemo_recent
-directly in Claude Desktop.`,
+directly in Claude Desktop and OpenCode.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		home, err := os.UserHomeDir()
 		if err != nil {
@@ -51,11 +52,11 @@ directly in Claude Desktop.`,
 		fmt.Println("Features enabled:")
 		fmt.Println("  - Claude Code: Skill auto-activates on context keywords")
 		fmt.Println("  - Claude Desktop: MCP tools (mnemo_search, mnemo_context, mnemo_recent)")
-		fmt.Println("  - OpenCode: Context survives session compaction")
+		fmt.Println("  - OpenCode: MCP tools (mnemo_search, mnemo_context, mnemo_recent)")
 		fmt.Println("  - Raycast: Search, context, and recent commands (macOS)")
 		fmt.Println("  - Background indexer: Sessions re-indexed every 30 minutes")
 		fmt.Println()
-		fmt.Println("Note: Restart Claude Desktop to activate MCP server.")
+		fmt.Println("Note: Restart Claude Desktop and OpenCode to activate MCP server.")
 	},
 }
 
@@ -99,6 +100,47 @@ func installMCPConfig(configPath, mnemoPath string) error {
 
 	if err := os.WriteFile(configPath, data, 0644); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
+	}
+
+	return nil
+}
+
+// installOpenCodeMCPConfig adds or updates mnemo MCP server in OpenCode config.
+func installOpenCodeMCPConfig(configPath, mnemoPath string) error {
+	var config map[string]interface{}
+
+	if data, err := os.ReadFile(configPath); err == nil {
+		if err := json.Unmarshal(data, &config); err != nil {
+			return fmt.Errorf("failed to parse existing OpenCode config: %w", err)
+		}
+	} else if os.IsNotExist(err) {
+		if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+			return fmt.Errorf("failed to create OpenCode config directory: %w", err)
+		}
+		config = make(map[string]interface{})
+	} else {
+		return fmt.Errorf("failed to read OpenCode config: %w", err)
+	}
+
+	mcp, ok := config["mcp"].(map[string]interface{})
+	if !ok {
+		mcp = make(map[string]interface{})
+		config["mcp"] = mcp
+	}
+
+	mcp["mnemo"] = map[string]interface{}{
+		"type":    "local",
+		"command": []string{mnemoPath, "serve"},
+		"enabled": true,
+	}
+
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal OpenCode config: %w", err)
+	}
+
+	if err := os.WriteFile(configPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write OpenCode config: %w", err)
 	}
 
 	return nil
@@ -149,6 +191,12 @@ func runInstallPlugins(home string) []string {
 	configPath := filepath.Join(claudeDesktopConfigDir, "claude_desktop_config.json")
 	if err := installMCPConfig(configPath, mnemoPath); err == nil {
 		results = append(results, "  ✓ MCP server configured")
+	}
+
+	// MCP server for OpenCode
+	opencodeConfigPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := installOpenCodeMCPConfig(opencodeConfigPath, mnemoPath); err == nil {
+		results = append(results, "  ✓ OpenCode MCP server configured")
 	}
 
 	// OpenCode plugin

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestInstallOpenCodeMCPConfigCreatesConfig(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), ".config", "opencode", "opencode.json")
+	mnemoPath := "/opt/homebrew/bin/mnemo"
+
+	if err := installOpenCodeMCPConfig(configPath, mnemoPath); err != nil {
+		t.Fatalf("installOpenCodeMCPConfig() error = %v", err)
+	}
+
+	config := readJSONFile(t, configPath)
+	mnemo := config["mcp"].(map[string]interface{})["mnemo"].(map[string]interface{})
+
+	if got, want := mnemo["type"], "local"; got != want {
+		t.Fatalf("mnemo.type = %v, want %v", got, want)
+	}
+	if got, want := mnemo["enabled"], true; got != want {
+		t.Fatalf("mnemo.enabled = %v, want %v", got, want)
+	}
+	if got, want := stringSlice(mnemo["command"]), []string{mnemoPath, "serve"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("mnemo.command = %v, want %v", got, want)
+	}
+}
+
+func TestInstallOpenCodeMCPConfigPreservesExistingConfig(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	existing := []byte(`{
+  "$schema": "https://opencode.ai/config.json",
+  "theme": "system",
+  "mcp": {
+    "github": {
+      "type": "local",
+      "command": ["gh", "mcp", "server"],
+      "enabled": false
+    }
+  }
+}`)
+	if err := os.WriteFile(configPath, existing, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installOpenCodeMCPConfig(configPath, "/usr/local/bin/mnemo"); err != nil {
+		t.Fatalf("installOpenCodeMCPConfig() error = %v", err)
+	}
+
+	config := readJSONFile(t, configPath)
+	if got, want := config["$schema"], "https://opencode.ai/config.json"; got != want {
+		t.Fatalf("$schema = %v, want %v", got, want)
+	}
+	if got, want := config["theme"], "system"; got != want {
+		t.Fatalf("theme = %v, want %v", got, want)
+	}
+
+	mcp := config["mcp"].(map[string]interface{})
+	github := mcp["github"].(map[string]interface{})
+	if got, want := stringSlice(github["command"]), []string{"gh", "mcp", "server"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("github.command = %v, want %v", got, want)
+	}
+	if _, ok := mcp["mnemo"]; !ok {
+		t.Fatal("mnemo MCP server was not added")
+	}
+}
+
+func TestInstallOpenCodeMCPConfigUpdatesMnemoEntry(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "opencode.json")
+	existing := []byte(`{
+  "mcp": {
+    "mnemo": {
+      "type": "local",
+      "command": ["old-mnemo", "serve"],
+      "enabled": false
+    }
+  }
+}`)
+	if err := os.WriteFile(configPath, existing, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installOpenCodeMCPConfig(configPath, "/new/mnemo"); err != nil {
+		t.Fatalf("installOpenCodeMCPConfig() error = %v", err)
+	}
+
+	config := readJSONFile(t, configPath)
+	mnemo := config["mcp"].(map[string]interface{})["mnemo"].(map[string]interface{})
+	if got, want := stringSlice(mnemo["command"]), []string{"/new/mnemo", "serve"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("mnemo.command = %v, want %v", got, want)
+	}
+	if got, want := mnemo["enabled"], true; got != want {
+		t.Fatalf("mnemo.enabled = %v, want %v", got, want)
+	}
+}
+
+func readJSONFile(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatal(err)
+	}
+	return config
+}
+
+func stringSlice(v interface{}) []string {
+	values, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		result = append(result, value.(string))
+	}
+	return result
+}


### PR DESCRIPTION
## Summary
- configure OpenCode MCP directly in ~/.config/opencode/opencode.json during `mnemo install`
- preserve existing OpenCode config and update only the `mcp.mnemo` server entry
- update README guidance and add installer tests

Closes #19

## Tests
- `go test -count=1 ./...`